### PR TITLE
Add support for running CI against forked PRs

### DIFF
--- a/.github/workflows/build-checks.yml
+++ b/.github/workflows/build-checks.yml
@@ -1,6 +1,7 @@
 name: Build checks
 on:
   - push
+  - pull_request
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We were only running on `push`, but need to run on `pull_request` as well.