### PR TITLE
added repo links in the table

### DIFF
--- a/src/pages/community/contributing.mdx
+++ b/src/pages/community/contributing.mdx
@@ -48,7 +48,7 @@ Delta Lake is supported by a wide set of developers from over 70 organizations a
     <td align="left">
       <a href="https://github.com/delta-io/delta">delta</a>
     </td>
-    <td align="right">97</td>
+    <td align="right">150</td>
     <td align="right">43</td>
   </tr>
   <tr>

--- a/src/pages/community/contributing.mdx
+++ b/src/pages/community/contributing.mdx
@@ -13,7 +13,7 @@ Delta Lake is an independent open-source project and not controlled by any singl
 
 Delta Lake is supported by a wide set of developers from over 70 organizations across multiple repositories. Since 2019, more than 190 developers have contributed to Delta Lake! The Delta Lake community is growing by leaps and bounds with more than 5500 members in the [Delta Users slack](https://dbricks.co/delta-users-slack)).
 
-<table cellpadding="5" width="500">
+<table cellpadding="5" width="600">
   <tr>
     <td
       align="left"
@@ -39,39 +39,57 @@ Delta Lake is supported by a wide set of developers from over 70 organizations a
   </tr>
   <tr>
     <td align="left">
-      <a href="https://github.com/delta-io/connectors">connectors</a>
-    </td>
-    <td align="right">21</td>
-    <td align="right">9</td>
-  </tr>
-  <tr>
-    <td align="left">
-      <a href="https://github.com/delta-io/delta">delta</a>
+      Delta Spark
+      <br />
+      <a href="https://github.com/delta-io/delta">
+        https://github.com/delta-io/delta
+      </a>
     </td>
     <td align="right">150</td>
     <td align="right">43</td>
   </tr>
   <tr>
     <td align="left">
-      <a href="https://github.com/delta-io/delta-rs">delta-rs</a>
+      Delta Connectors (Hive, Flink, etc.)
+      <br />
+      <a href="https://github.com/delta-io/connectors">
+        https://github.com/delta-io/connectors
+      </a>
     </td>
-    <td align="right">54</td>
+    <td align="right">19</td>
+    <td align="right">9</td>
+  </tr>
+  <tr>
+    <td align="left">
+      Delta Rust
+      <br />
+      <a href="https://github.com/delta-io/delta-rs">
+        https://github.com/delta-io/delta-rs
+      </a>
+    </td>
+    <td align="right">43</td>
     <td align="right">26</td>
   </tr>
   <tr>
     <td align="left">
-      <a href="https://github.com/delta-io/delta-sharing">delta-sharing</a>
+      Delta Sharing
+      <br />
+      <a href="https://github.com/delta-io/delta-sharing">
+        https://github.com/delta-io/delta-sharing
+      </a>
     </td>
-    <td align="right">19</td>
+    <td align="right">16</td>
     <td align="right">2</td>
   </tr>
   <tr>
     <td align="left">
+      Kafka Delta Ingest
+      <br />
       <a href="https://github.com/delta-io/kafka-delta-ingest">
-        kafka-delta-ingest
+        https://github.com/delta-io/kafka-delta-ingest
       </a>
     </td>
-    <td align="right">10</td>
+    <td align="right">6</td>
     <td align="right">2</td>
   </tr>
 </table>

--- a/src/pages/community/contributing.mdx
+++ b/src/pages/community/contributing.mdx
@@ -38,27 +38,39 @@ Delta Lake is supported by a wide set of developers from over 70 organizations a
     </td>
   </tr>
   <tr>
-    <td align="left">connectors</td>
+    <td align="left">
+      <a href="https://github.com/delta-io/connectors">connectors</a>
+    </td>
     <td align="right">21</td>
     <td align="right">9</td>
   </tr>
   <tr>
-    <td align="left">delta</td>
+    <td align="left">
+      <a href="https://github.com/delta-io/delta">delta</a>
+    </td>
     <td align="right">97</td>
     <td align="right">43</td>
   </tr>
   <tr>
-    <td align="left">delta-rs</td>
+    <td align="left">
+      <a href="https://github.com/delta-io/delta-rs">delta-rs</a>
+    </td>
     <td align="right">54</td>
     <td align="right">26</td>
   </tr>
   <tr>
-    <td align="left">delta-sharing</td>
+    <td align="left">
+      <a href="https://github.com/delta-io/delta-sharing">delta-sharing</a>
+    </td>
     <td align="right">19</td>
     <td align="right">2</td>
   </tr>
   <tr>
-    <td align="left">kafka-delta-ingest</td>
+    <td align="left">
+      <a href="https://github.com/delta-io/kafka-delta-ingest">
+        kafka-delta-ingest
+      </a>
+    </td>
     <td align="right">10</td>
     <td align="right">2</td>
   </tr>


### PR DESCRIPTION
Only added to contributing.mdx since it is the only visible version on the website for now but can also update index.mdx if you like. Index.mdx has the same table but the page is not currently reachable through the current navigation

Signed-off-by: John ODwyer <johnpodwyer@gmail.com>