### PR TITLE
Fixed Delta-users slack links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,13 +4,13 @@ We happily welcome contributions to [Delta Lake Website](https://delta.io/). We 
 
 Delta Lake is an independent open-source project and not controlled by any single company. To emphasize this we joined the Delta Lake Project in 2019, which is a sub-project of the Linux Foundation Projects. Within the project, we make decisions based on [these rules](https://delta.io/pdfs/delta-charter.pdf).
 
-Delta Lake is supported by a wide set of developers from over 50 organizations across multiple repositories. Since 2019, more than 190 developers have contributed to Delta Lake! The Delta Lake community is growing by leaps and bounds with more than 5500 members in the [Delta Users slack](https://go.delta.io/delta-users)).
+Delta Lake is supported by a wide set of developers from over 50 organizations across multiple repositories. Since 2019, more than 190 developers have contributed to Delta Lake! The Delta Lake community is growing by leaps and bounds with more than 5500 members in the [Delta Users slack](https://go.delta.io/slack)).
 
 For more information, please refer to the [founding technical charter](https://delta.io/pdfs/delta-charter.pdf).
 
 # Communication
 
-- Before starting work on a major feature, please reach out to us via [GitHub](https://github.com/delta-io/delta/issues), [Slack](https://go.delta.io/delta-users), [email](https://groups.google.com/g/delta-users), etc. We will make sure no one else is already working on it and ask you to open a GitHub issue.
+- Before starting work on a major feature, please reach out to us via [GitHub](https://github.com/delta-io/delta/issues), [Slack](https://go.delta.io/slack), [email](https://groups.google.com/g/delta-users), etc. We will make sure no one else is already working on it and ask you to open a GitHub issue.
 - A "major feature" is defined as any change that is > 100 LOC altered (not including tests), or changes any user-facing behavior.
 - We will use the GitHub issue to discuss the feature and come to agreement.
 - This is to prevent your time being wasted, as well as ours.

--- a/config/menus.js
+++ b/config/menus.js
@@ -56,7 +56,7 @@ const social = [
   },
   {
     label: "Slack Group",
-    url: "https://go.delta.io/delta-users",
+    url: "https://go.delta.io/slack",
     icon: "slack",
   },
   {

--- a/src/components/pages/shared/SocialTiles/index.jsx
+++ b/src/components/pages/shared/SocialTiles/index.jsx
@@ -11,7 +11,7 @@ const communities = [
   {
     thumbnail: slack,
     label: "Slack Channel",
-    url: "https://go.delta.io/delta-users",
+    url: "https://go.delta.io/slack",
   },
   {
     thumbnail: googleGroups,

--- a/src/pages/community/getting-help.mdx
+++ b/src/pages/community/getting-help.mdx
@@ -5,7 +5,7 @@ width: full
 
 There are four ways that the community can ask questions/issues and we need your help answering them to continue to grow the community. Answering and properly documenting common questions is very important and is a primary place where contributions are needed. Below are the different ways that you can help answer questions:
 
-## [Delta Users Slack Channel](https://go.delta.io/delta-users)
+## [Delta Users Slack Channel](https://go.delta.io/slack)
 
 This is the place where the maximum traffic occurs, and where most people in the community are. However, these responses are not easily searchable so we have broken discussions into different channels:
 
@@ -26,7 +26,7 @@ When answering questions, the most important thing to remember is to make sure t
 Github issues get much fewer posts than Slack, but whoever does, it's usually a technical question about a bug or feature. The answers are searchable, so it's even more important that the responses be correct and unambiguous. Roughly follow the same suggestions as with Slack with the following differences:
 
 - Github issues are unlikely to get non-Delta-Lake and non-technical questions. Rather you may get deeper technical questions, hard bugs and complex feature requests. Please pull in established contributors to discuss these issues.
-- If it’s a question, redirect to them to [Slack](https://delta-users.slack.com/) or [Google Groups](https://groups.google.com/g/delta-users) to discuss
+- If it’s a question, redirect to them to [Slack](https://go.delta.io/slack) or [Google Groups](https://groups.google.com/g/delta-users) to discuss
 - If the proposed solution is suboptimal, engage with them to see if you can make it better
 - **If issues are >=6 months** and if there isn't anything new to add, GitHub automation and/or Delta Lake committers may close the issue, though those issues can be re-opened by anyone if this was a mistake.
 

--- a/src/pages/community/index.mdx
+++ b/src/pages/community/index.mdx
@@ -7,7 +7,7 @@ width: full
 
 Delta Lake is an independent open-source project and not controlled by any single company. To emphasize this we joined the Delta Lake Project in 2019, which is a sub-project of the Linux Foundation Projects. Within the project, we make decisions based on [these rules](https://delta.io/pdfs/delta-charter.pdf).
 
-Delta Lake is supported by a wide set of developers from over 70 organizations across multiple repositories. Since 2019, more than 190 developers have contributed to Delta Lake across more than 5 repositories! The Delta Lake community is growing by leaps and bounds with more than 5500 members in the [Delta Users slack](https://go.delta.io/delta-users)).
+Delta Lake is supported by a wide set of developers from over 70 organizations across multiple repositories. Since 2019, more than 190 developers have contributed to Delta Lake across more than 5 repositories! The Delta Lake community is growing by leaps and bounds with more than 5500 members in the [Delta Users slack](https://go.delta.io/slack)).
 
 <table cellpadding="5" width="500">
   <tr>

--- a/src/pages/roadmap.mdx
+++ b/src/pages/roadmap.mdx
@@ -13,7 +13,7 @@ This is the proposed Delta Lake 2022 H1 roadmap discussion thread. Below are the
 
 ---
 
-Based on the overwhelming feedback from the Delta Users [Slack](https://go.delta.io/delta-users), [Google Groups](https://groups.google.com/forum/#!forum/delta-users), Community AMAs (on [Delta Lake YouTube](http://youtube.com/c/deltalake)), Delta Lake 2021H2 survey, and [2021H2 roadmap](https://github.com/delta-io/delta/issues/748), we propose the following Delta Lake performance enhancements in the next two quarters.
+Based on the overwhelming feedback from the Delta Users [Slack](https://go.delta.io/slack), [Google Groups](https://groups.google.com/forum/#!forum/delta-users), Community AMAs (on [Delta Lake YouTube](http://youtube.com/c/deltalake)), Delta Lake 2021H2 survey, and [2021H2 roadmap](https://github.com/delta-io/delta/issues/748), we propose the following Delta Lake performance enhancements in the next two quarters.
 
 | Issue                                                 | Description                                                                                                                                                                             | Target CY2022                                                |
 | :---------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------- |


### PR DESCRIPTION
The existing links unnecessarily restricts (or seem to restrict) signups to a limited email domains.