### PR TITLE
Update redirection of connectors URL

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -8,3 +8,4 @@
 /tutorials/* /learn/tutorials    301
 /community/contributing  /community-page 301
 /community/adoption      /community-page 301 
+/connectors /integrations   301


### PR DESCRIPTION
Some older links were pointed to https://delta.io/connectors - they need to be redirected to https://delta.io/integrations