### PR TITLE
Update getting-started.mdx

### DIFF
--- a/src/pages/learn/getting-started.mdx
+++ b/src/pages/learn/getting-started.mdx
@@ -77,7 +77,7 @@ builder = pyspark.sql.SparkSession.builder.appName("MyApp") \
     .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension") \
     .config("spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog")
 
-spark = spark = configure_spark_with_delta_pip(builder).getOrCreate()
+spark = configure_spark_with_delta_pip(builder).getOrCreate()
 ```
 
 ## Create a table


### PR DESCRIPTION
Removing the duplicated assignment 'spark = spark' in code example.