### PR TITLE
Add support for code tabs in MDX pages

### DIFF
--- a/src/components/CodeTabs.jsx
+++ b/src/components/CodeTabs.jsx
@@ -1,0 +1,66 @@
+import React, { Children, useState, isValidElement } from "react";
+import styled from "styled-components";
+
+const Tab = styled.button.attrs({ type: "button" })`
+  appearance: none;
+  color: ${(props) => (props.isActive ? props.theme.colors.primary : "white")};
+  padding: ${(props) => props.theme.spacing.sm};
+  line-height: 1;
+  background-color: transparent;
+  border: 0;
+  border-bottom: 2px solid
+    ${(props) => (props.isActive ? props.theme.colors.primary : "transparent")};
+  margin-bottom: -2px;
+`;
+
+const Tabs = styled.div`
+  display: flex;
+  background-color: #3f3f3f;
+  border-bottom: 2px solid #666;
+  border-radius: 0.25em 0.25em 0 0;
+`;
+
+const CodeBlockWrapper = styled.div`
+  code {
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+  }
+`;
+
+const CodeTabs = (props) => {
+  const { children, tabs } = props;
+  const [tabIndex, setTabIndex] = useState(0);
+
+  const codeBlocks = Children.toArray(children)
+    .filter(
+      (child) =>
+        isValidElement(child) &&
+        typeof child.type === "function" &&
+        child.type.name === "pre"
+    )
+    .map((codeBlock) => {
+      const lang =
+        codeBlock.props.children.props.className.match(/language-(\w+)/)?.[1] ??
+        "txt";
+      return [lang, codeBlock];
+    });
+
+  return (
+    <div>
+      <Tabs>
+        {codeBlocks.map(([language], index) => (
+          <Tab isActive={index === tabIndex} onClick={() => setTabIndex(index)}>
+            {(tabs?.length && tabs[index]) ?? language}
+          </Tab>
+        ))}
+      </Tabs>
+      <CodeBlockWrapper>
+        {codeBlocks
+          .filter((unused, index) => index === tabIndex)
+          .map(([, codeBlock]) => codeBlock)}
+      </CodeBlockWrapper>
+    </div>
+  );
+};
+
+export default CodeTabs;

--- a/src/components/MDX.jsx
+++ b/src/components/MDX.jsx
@@ -11,6 +11,7 @@ import ImageStripDataList from "src/components/pages/shared/ImageStripDataList";
 import JsonCardDataList from "src/components/pages/shared/JsonCardDataList";
 import OrganizationTiles from "src/components/pages/shared/OrganizationTiles";
 import SocialTiles from "src/components/pages/shared/SocialTiles";
+import CodeTabs from "src/components/CodeTabs";
 
 const MarkdownContent = styled.div`
   .align-image-left .gatsby-resp-image-wrapper {
@@ -240,6 +241,7 @@ const mdxComponents = {
   JsonCardDataList,
   OrganizationTiles,
   SocialTiles,
+  CodeTabs,
 };
 
 const MDX = (props) => {


### PR DESCRIPTION
This PR adds the `<CodeTabs />` component to MDX pages.

## How to use

Simply wrap multiple code blocks with CodeTabs:

````mdx

<CodeTabs>

```js
const add = (a, b) => a + b;
```

```ts
const add = (a: number, b:number): number => a + b;
```

</CodeTabs>

````

This will result in the following:

<img width="814" alt="Screen Shot 2022-10-10 at 10 23 10 PM" src="https://user-images.githubusercontent.com/391085/195003641-10579e98-9f3d-4eed-8623-a8e975acca3f.png">

Tabs are sorted in the order that they are written.

## Customizing tab names

Tab names will default to the language name (`js`, `python`, `java`, etc) and fall back to `txt` if no language is provided. Tab names can be customized by utilizing the `tabs` prop on the `<CustomTabs />` component.

````mdx

<CodeTabs tabs={["FooBar", "BazQux"]}>

```js
const add = (a, b) => a + b;
```

```ts
const add = (a: number, b:number): number => a + b;
```

</CodeTabs>

````

This will result in the following:

<img width="813" alt="Screen Shot 2022-10-10 at 10 29 17 PM" src="https://user-images.githubusercontent.com/391085/195004371-45a53688-f88e-4fdf-94ee-b6dffdd651cb.png">

## Indentation and spacing

MDX v2 makes it easier to work with nested markdown in components. As long as you don't indent code blocks and wrap each block in a newline you will have no trouble working with blocks. The linter will handle most of this for you anyway.

Note that any other elements which are not code blocks will not be displayed.
