### PR TITLE
adding meta tags

### DIFF
--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -27,6 +27,11 @@ const SEO = (props) => {
   return (
     <>
       <title>{documentTitle}</title>
+      <meta name="name" content={documentTitle} />
+      <meta
+        name="image"
+        property={`${site.siteMetadata.siteUrl}${thumbnailPath}`}
+      />
       {description && <meta name="description" content={description} />}
       <meta property="og:title" content={title} />
       {description && <meta property="og:description" content={description} />}
@@ -38,6 +43,10 @@ const SEO = (props) => {
       <meta name="twitter:card" content="summary" />
       <meta name="twitter:creator" content={site.siteMetadata.twitter} />
       <meta name="twitter:title" content={title} />
+      <meta
+        name="twitter:image"
+        property={`${site.siteMetadata.siteUrl}${thumbnailPath}`}
+      />
       {description && <meta name="twitter:description" content={description} />}
       {children}
     </>

--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -30,22 +30,19 @@ const SEO = (props) => {
       <meta name="name" content={documentTitle} />
       <meta
         name="image"
-        property={`${site.siteMetadata.siteUrl}${thumbnailPath}`}
+        property="og:image"
+        content={`${site.siteMetadata.siteUrl}${thumbnailPath}`}
       />
       {description && <meta name="description" content={description} />}
       <meta property="og:title" content={title} />
       {description && <meta property="og:description" content={description} />}
-      <meta
-        name="og:image"
-        property={`${site.siteMetadata.siteUrl}${thumbnailPath}`}
-      />
       <meta name="og:type" property="website" />
       <meta name="twitter:card" content="summary" />
       <meta name="twitter:creator" content={site.siteMetadata.twitter} />
       <meta name="twitter:title" content={title} />
       <meta
         name="twitter:image"
-        property={`${site.siteMetadata.siteUrl}${thumbnailPath}`}
+        content={`${site.siteMetadata.siteUrl}${thumbnailPath}`}
       />
       {description && <meta name="twitter:description" content={description} />}
       {children}


### PR DESCRIPTION
Noticed platforms were having trouble resolving our thumbnails through `og:image`.

I ran a page through a metadata checker: https://www.heymeta.com/url/delta.io/blog/2023-02-14-delta-lake-merge/

Which output the following suggestion:

```
<!-- HTML Meta Tags -->
<title>Delta Lake Merge</title>
<meta name="description" content="This post shows how to use MERGE with Delta tables.">

<!-- Google / Search Engine Tags -->
<meta itemprop="name" content="Delta Lake Merge">
<meta itemprop="description" content="This post shows how to use MERGE with Delta tables.">
<meta itemprop="image" content="https://delta.io/static/438ab0f829907abb1c43e3517879188b/20a3c/thumbnail.png">

<!-- Facebook Meta Tags -->
<meta property="og:url" content="https://delta.io/blog/2023-02-14-delta-lake-merge">
<meta property="og:type" content="website">
<meta property="og:title" content="Delta Lake Merge">
<meta property="og:description" content="This post shows how to use MERGE with Delta tables.">
<meta property="og:image" content="https://delta.io/static/438ab0f829907abb1c43e3517879188b/20a3c/thumbnail.png">

<!-- Twitter Meta Tags -->
<meta name="twitter:card" content="summary_large_image">
<meta name="twitter:title" content="Delta Lake Merge">
<meta name="twitter:description" content="This post shows how to use MERGE with Delta tables.">
<meta name="twitter:image" content="https://delta.io/static/438ab0f829907abb1c43e3517879188b/20a3c/thumbnail.png">
```

This PR implements some of the missing tags, hopefully this improves the post view in social links.