### PR TITLE
Capitalize H in GitHub

### DIFF
--- a/src/pages/learn/getting-started.mdx
+++ b/src/pages/learn/getting-started.mdx
@@ -10,7 +10,7 @@ This guide helps you quickly explore the main features of Delta Lake. It provide
 Follow these instructions to set up Delta Lake with Spark. You can run the steps in this guide on your local machine in the following two ways:
 
 1. Run interactively: Start the Spark shell (Scala or Python) with Delta Lake and run the code snippets interactively in the shell.
-2. Run as a project: Set up a Maven or SBT project (Scala or Java) with Delta Lake, copy the code snippets into a source file, and run the project. Alternatively, you can use the [examples provided in the Github repository](https://github.com/delta-io/delta/tree/master/examples).
+2. Run as a project: Set up a Maven or SBT project (Scala or Java) with Delta Lake, copy the code snippets into a source file, and run the project. Alternatively, you can use the [examples provided in the GitHub repository](https://github.com/delta-io/delta/tree/master/examples).
 
 ### Set up interactive shell
 


### PR DESCRIPTION
The "H" in "GitHub" should be capitalized. It's not in the "Getting Started" page.

This PR resolves the issue by applying capitalization to the letter H.