### PR TITLE
no longer need date in URI (blog folder name), just add it as a field…

### DIFF
--- a/src/blog/2023-07-05-deletion-vectors/index.mdx
+++ b/src/blog/2023-07-05-deletion-vectors/index.mdx
@@ -3,7 +3,7 @@ title: Delta Lake Deletion Vectors
 description: This blog introduces the new Deletion Vectors table feature for Delta Lake tables, and explains how Deletion Vectors speed up operations that modify existing data in your lakehouse.
 thumbnail: ./thumbnail.png
 author: Nick Karpov
-date:2023-07-05
+date: 2023-07-05
 ---
 
 This blog introduces the new Deletion Vectors table feature for Delta Lake tables, and explains how Deletion Vectors speed up operations that modify existing data in your lakehouse.

--- a/src/blog/2023-07-05-deletion-vectors/index.mdx
+++ b/src/blog/2023-07-05-deletion-vectors/index.mdx
@@ -3,6 +3,7 @@ title: Delta Lake Deletion Vectors
 description: This blog introduces the new Deletion Vectors table feature for Delta Lake tables, and explains how Deletion Vectors speed up operations that modify existing data in your lakehouse.
 thumbnail: ./thumbnail.png
 author: Nick Karpov
+date:2023-07-05
 ---
 
 This blog introduces the new Deletion Vectors table feature for Delta Lake tables, and explains how Deletion Vectors speed up operations that modify existing data in your lakehouse.

--- a/src/blog/2023-07-07-delta-lake-transaction-log-protocol/index.mdx
+++ b/src/blog/2023-07-07-delta-lake-transaction-log-protocol/index.mdx
@@ -3,7 +3,7 @@ title: Delta Lake’s transaction log protocol and its implementations
 description: This blog explains the Delta Lake transaction log protocol and its various implementation.
 thumbnail: ./thumbnail.png
 author: Matthew Powers
-date:2023-07-07
+date: 2023-07-07
 ---
 
 This post explains the [Delta Lake transaction log protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md), the [delta-io/delta](https://github.com/delta-io/delta/) reference implementation of the Delta Lake transaction log protocol, and the other known Delta Lake implementations.

--- a/src/blog/2023-07-07-delta-lake-transaction-log-protocol/index.mdx
+++ b/src/blog/2023-07-07-delta-lake-transaction-log-protocol/index.mdx
@@ -3,6 +3,7 @@ title: Delta Lake’s transaction log protocol and its implementations
 description: This blog explains the Delta Lake transaction log protocol and its various implementation.
 thumbnail: ./thumbnail.png
 author: Matthew Powers
+date:2023-07-07
 ---
 
 This post explains the [Delta Lake transaction log protocol](https://github.com/delta-io/delta/blob/master/PROTOCOL.md), the [delta-io/delta](https://github.com/delta-io/delta/) reference implementation of the Delta Lake transaction log protocol, and the other known Delta Lake implementations.

--- a/src/blog/2023-07-14-delta-lake-change-data-feed-cdf/index.mdx
+++ b/src/blog/2023-07-14-delta-lake-change-data-feed-cdf/index.mdx
@@ -3,7 +3,7 @@ title: Delta Lake Change Data Feed (CDF)
 description: This blog shows how to enable and use the Delta Lake Change Data Feed.
 thumbnail: ./thumbnail.png
 author: Nick Karpov, Matthew Powers
-date:2023-07-14
+date: 2023-07-14
 ---
 
 The Delta Lake Change Data Feed (CDF) allows you to automatically track Delta table row-level changes.

--- a/src/blog/2023-07-14-delta-lake-change-data-feed-cdf/index.mdx
+++ b/src/blog/2023-07-14-delta-lake-change-data-feed-cdf/index.mdx
@@ -3,6 +3,7 @@ title: Delta Lake Change Data Feed (CDF)
 description: This blog shows how to enable and use the Delta Lake Change Data Feed.
 thumbnail: ./thumbnail.png
 author: Nick Karpov, Matthew Powers
+date:2023-07-14
 ---
 
 The Delta Lake Change Data Feed (CDF) allows you to automatically track Delta table row-level changes.

--- a/src/components/pages/index/LatestUpdateSection/index.jsx
+++ b/src/components/pages/index/LatestUpdateSection/index.jsx
@@ -12,7 +12,7 @@ const LatestUpdateSection = () => {
   const data = useStaticQuery(graphql`
     query {
       allMdx(
-        sort: { fields: [fields___date], order: DESC }
+        sort: { fields: [frontmatter___date], order: DESC }
         filter: { fields: { pageType: { eq: "blog" } } }
       ) {
         edges {
@@ -26,9 +26,9 @@ const LatestUpdateSection = () => {
                   gatsbyImageData
                 }
               }
+              date(formatString: "MMMM D, YYYY")
             }
             fields {
-              date(formatString: "MMMM D, YYYY")
               slug
             }
           }
@@ -44,6 +44,7 @@ const LatestUpdateSection = () => {
       title: frontmatter.title,
       thumbnail: frontmatter.thumbnail,
       url: fields.slug,
+      date: fields.date,
     }))
     .slice(0, 5);
 

--- a/src/templates/collections/blog.jsx
+++ b/src/templates/collections/blog.jsx
@@ -68,7 +68,7 @@ export const Head = ({ pageContext }) => {
 export const pageQuery = graphql`
   query {
     allMdx(
-      sort: { fields: [fields___date], order: DESC }
+      sort: { fields: [frontmatter___date], order: DESC }
       filter: { fields: { pageType: { eq: "blog" } } }
     ) {
       edges {


### PR DESCRIPTION
This PR fixes the Latest and Blog sections to correctly only use the field date in the `.mdx` files, instead of the folder based URI.

This allows us to name blogs without having the date in them etc.