### PR TITLE
Fully-qualified URLs for 'community'.

### DIFF
--- a/src/blog/delta-lake-3-0/index.mdx
+++ b/src/blog/delta-lake-3-0/index.mdx
@@ -102,7 +102,7 @@ Adam Binford, Ahir Reddy, Ala Luszczak, Alex, Allen Reese, Allison Portis, Ami O
 
 We’d also like to extend special things to Scott Sandre for his contribution.
 
-And, as always, a huge thank you to the contributions from our open-source [community](delta.io/community).
+And, as always, a huge thank you to the contributions from our open-source [community](https://delta.io/community).
 
 ## Join the community today!
 

--- a/src/blog/delta-lake-3-1/index.mdx
+++ b/src/blog/delta-lake-3-1/index.mdx
@@ -132,7 +132,7 @@ Ala Luszczak, Allison Portis, Ami Oka, Amogh Akshintala, Andreas Chatzistergiou,
 
 We’d also like to extend special things to Venki Korukanti for his contributions in making the release.
 
-And, as always, a huge thank you to the contributions from our open source [community](delta.io/community).
+And, as always, a huge thank you to the contributions from our open source [community](https://delta.io/community).
 
 # Join the community today!
 


### PR DESCRIPTION
Fixing broken links in 3.0.0 and 3.1.0 release blogs.