### PR TITLE
Blog "Delta Without Spark": add link to bigquery blog

### DIFF
--- a/src/blog/delta-lake-without-spark/index.mdx
+++ b/src/blog/delta-lake-without-spark/index.mdx
@@ -378,6 +378,8 @@ After creating your Delta Lake BigLake, you can query it using GoogleSQL. For ex
 
 You do not need to write any Spark to use Delta Lake with Google BigQuery.
 
+Read more in the [dedicated blog post](https://delta.io/blog/query-delta-lake-bigquery/).
+
 #### Known Limitations
 
 - This connector is available as a pre-GA feature. Pre-GA features are available "as is" and might have limited support.


### PR DESCRIPTION
This adds a link to the new BigQuery blog post