### PR TITLE
bump homepage announcement to 3.3.0

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -26,9 +26,9 @@ const HomePage = () => {
   return (
     <PageLayout>
       <AnnouncementSection
-        title="Announcing Delta Lake 3.2.0 on Apache Spark™ 3.5"
+        title="Announcing Delta Lake 3.3.0 on Apache Spark™ 3.5"
         description="Try out the latest release today!"
-        url="https://github.com/delta-io/delta/releases/tag/v3.2.0"
+        url="https://github.com/delta-io/delta/releases/tag/v3.3.0"
       />
       <HeroSection
         title="Build Lakehouses with Delta Lake"


### PR DESCRIPTION
Simple change to the homepage to include the reference to the 3.3.0 delta release. 

Signed-off-by: Scott Haines <newfrontcreative@gmail.com>