### PR TITLE
Ignore .netlify folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ pnpm-debug.log*
 .idea/
 
 .env
+
+# Netlify
+.netlify


### PR DESCRIPTION
Follow up from #570, the `.netlify` directory didn't get ignored by git. This folder is used as a cache for netlify build functions and should not get checked in by mistake.