### PR TITLE
Show latest blog posts on home page

### DIFF
--- a/src/components/Home/LatestUpdatesSection.astro
+++ b/src/components/Home/LatestUpdatesSection.astro
@@ -5,13 +5,16 @@ import ImageStrip from "../ImageStrip.astro";
 
 const posts = await getCollection("blog");
 
-const latestBlogs = posts.slice(0, 5).map((post) => {
-  return {
-    title: post.data.title,
-    thumbnail: post.data.thumbnail,
-    url: `/blog/${post.id}`,
-  };
-});
+const latestBlogs = posts
+  .sort((a, b) => b.data.publishedAt.getTime() - a.data.publishedAt.getTime())
+  .slice(0, 5)
+  .map((post) => {
+    return {
+      title: post.data.title,
+      thumbnail: post.data.thumbnail,
+      url: `/blog/${post.id}`,
+    };
+  });
 ---
 
 <Section


### PR DESCRIPTION
This PR fixes a bug where we weren't seeing the latest 5 posts on the home page.

Before:

<img width="1240" height="355" alt="Screenshot 2025-11-15 at 3 35 22 PM" src="https://github.com/user-attachments/assets/e9f88066-5346-4b92-ac9d-36e87a7158fe" />

After:

<img width="1251" height="345" alt="Screenshot 2025-11-15 at 3 47 33 PM" src="https://github.com/user-attachments/assets/b2d0fad1-fec7-4141-8dea-3e16a6aed1f8" />