### PR TITLE
changed the blog description metadata

### DIFF
--- a/src/content/blog/2025-09-25-Delta-Lake-4.0/index.md
+++ b/src/content/blog/2025-09-25-Delta-Lake-4.0/index.md
@@ -1,6 +1,6 @@
 ---
 title: Delta Lake 4.0
-description: My summary of Delta Lake 4.0.
+description: We’re thrilled to announce the release of Delta Lake 4.0, a milestone release packed with powerful new features, performance optimizations, and foundational enhancements for the future of open data lakehouses. With new catalog integration, enhanced support for semi-structured data, smarter change tracking, and improved performance, this release delivers practical solutions to everyday data challenges.
 thumbnail: ./thumbnail.png
 author:
   - carly-akerly


### PR DESCRIPTION
## What changed?

The blog description wasn't what was intended to be visible. I've updated with the real description.

## Screenshot
<img width="1082" height="534" alt="Screenshot 2026-01-30 at 8 16 17 AM" src="https://github.com/user-attachments/assets/72abaddf-76cd-4b6c-8fb3-99fd7471bec2" />
