### PR TITLE
Modified the Release notes blog

### DIFF
--- a/src/content/blog/2026-03-01-delta-lake-4-1-0-released/index.md
+++ b/src/content/blog/2026-03-01-delta-lake-4-1-0-released/index.md
@@ -46,7 +46,7 @@ While backward-compatible artifacts without the suffix are still published for t
 **Key benefits include:**
 
 - **Choice of Runtime**: Explicit artifacts for both Spark 4.1 and Spark 4.0.
-- **Java 17 Requirement**: This release fully embraces Java 17; Spark 3.5 support has been officially dropped.
+- **Java 17 Requirement**: This release fully embraces Java 17; Spark 3.5 support has been officially dropped. All releases will be focused on alignment with Spark >= 4.
 
 ## Server-Side Planning (Preview)
 

--- a/src/content/blog/2026-03-01-delta-lake-4-1-0-released/index.md
+++ b/src/content/blog/2026-03-01-delta-lake-4-1-0-released/index.md
@@ -116,7 +116,6 @@ The following are the key compatibility and breaking changes introduced in this 
 
 - **Java 17+**: Required for Delta Lake 4.1.0.
 - **Spark 3.5 Support Dropped**: Users must upgrade to Spark 4.0.1 or 4.1.0.
-- **Manual VACUUM Blocked**: For catalog-managed tables, data lifecycle must be managed through the catalog.
 
 ## Try Delta Lake 4.1.0 and Get Involved
 


### PR DESCRIPTION
## What changed?

Removed an ambiguous statement from the notes about catalog-managed tables. Will dive into a longer post about those with the 4.2 release. 
