### PR TITLE
update-latest-release

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -24,9 +24,9 @@ const diagramOffsets = {
 
 <Layout title="Home">
   <AnnouncementSection
-    title="Announcing Delta Lake 4.0 on Apache Spark™ 4.0"
+    title="Announcing Delta Lake 4.2.0 on Apache Spark™ 4.1.0"
     description="Try out the latest release today!"
-    url="https://github.com/delta-io/delta/releases/tag/v4.0.0"
+    url="https://github.com/delta-io/delta/releases/tag/v4.2.0"
   />
   <HeroSection
     title="Build Lakehouses with Delta Lake"


### PR DESCRIPTION
I've updated the latest release to point to the 4.2.0 release on the top of the website.

## What changed?
Updated the latest release to track the 4.2.0 release vs the old 4.0.0 release.

## Screenshot
This is what is currently on the website. That release is from June 9th, 2025
<img width="1216" height="251" alt="Screenshot 2026-04-17 at 4 07 22 PM" src="https://github.com/user-attachments/assets/acbae8d7-602d-4116-946b-49035f417617" />
